### PR TITLE
Fix parsing comments inline on attributes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,21 +8,19 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    container:
-      image: crystallang/crystal
-
+    permissions:
+      contents: write
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+    - uses: crystal-lang/install-crystal@v1
     - name: Install dependencies
       run: shards install
     - name: Generate docs
       run: crystal docs
     - name: Deploy docs
-      uses: peaceiris/actions-gh-pages@v2.8.0
-      env:
-        ACTIONS_DEPLOY_KEY: ${{ secrets.ACTIONS_DEPLOY_KEY }}
-        PUBLISH_BRANCH: gh-pages
-        PUBLISH_DIR: ./docs
+      uses: peaceiris/actions-gh-pages@v4
+      if: github.ref == 'refs/heads/master'
       with:
-        emptyCommits: false
+        allow_empty_commit: true
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs

--- a/spec/hcl/parser_spec.cr
+++ b/spec/hcl/parser_spec.cr
@@ -329,7 +329,7 @@ describe HCL::Parser do
           ami               = "ami-12345"
           count             = 2
           source_dest_check = false
-          another_boolean = "true"
+          another_boolean = "true" # this is a string because... reasons
           something_i_want_default = null
 
           connection {

--- a/src/hcl/grammar.cr
+++ b/src/hcl/grammar.cr
@@ -11,7 +11,7 @@ module HCL
 
     comment_char = range(' ', 0x10FFFF_u32)
     comment = (
-      char('#') >> (~newline >> comment_char).repeat >> newline
+      char('#') >> (~newline >> comment_char).repeat
     ).named(:comment, false)
     multi_comment_char = ~str("*/") >> (comment_char | newline)
     multi_comment = (

--- a/src/hcl_parse_test.cr
+++ b/src/hcl_parse_test.cr
@@ -54,6 +54,8 @@ variable "list_of_things" {
 block {
   cond = "%{ if true ~} hello %{~ endif }"
   for_expr = "%{ for i, v in [true, 1, "hello"] }${i}: ${v}\n%{ endfor }"
+  some_property = [] # i am commenting about it
+  another_prop = true
 }
 
 HEREDOC


### PR DESCRIPTION
The newline at the end of the comment is typically accounted for as part of the attribute or consumed as part of the whitespace between body elements, and this was erroneously causing it to expect two newlines